### PR TITLE
add hmac to encrypt API only

### DIFF
--- a/rncryptor.cabal
+++ b/rncryptor.cabal
@@ -31,9 +31,8 @@ library
     , random >= 1.0.0.1
     , QuickCheck >= 2.6 && < 2.9
     , io-streams >= 1.2.0.0
-    , cipher-aes >= 0.2.9
-    , pbkdf >= 1.1.1.1
-    , cryptohash-sha256 >= 0.11.100.1
+    , cryptonite
+    , memory
   hs-source-dirs:
     src
   default-language:
@@ -65,8 +64,8 @@ executable rncryptor-decrypt
   build-depends:
       base
     , bytestring
+    , cryptonite
     , io-streams
-    , cipher-aes
     , rncryptor -any
   hs-source-dirs:
     example
@@ -82,7 +81,7 @@ executable rncryptor-encrypt
       base
     , bytestring
     , io-streams
-    , cipher-aes
+    , cryptonite
     , rncryptor -any
   hs-source-dirs:
     example

--- a/rncryptor.cabal
+++ b/rncryptor.cabal
@@ -33,6 +33,7 @@ library
     , io-streams >= 1.2.0.0
     , cipher-aes >= 0.2.9
     , pbkdf >= 1.1.1.1
+    , cryptohash-sha256 >= 0.11.100.1
   hs-source-dirs:
     src
   default-language:

--- a/rncryptor.cabal
+++ b/rncryptor.cabal
@@ -31,7 +31,7 @@ library
     , random >= 1.0.0.1
     , QuickCheck >= 2.6 && < 2.9
     , io-streams >= 1.2.0.0
-    , cryptonite
+    , cryptonite >= 0.15
     , memory
   hs-source-dirs:
     src
@@ -64,7 +64,7 @@ executable rncryptor-decrypt
   build-depends:
       base
     , bytestring
-    , cryptonite
+    , cryptonite >= 0.15
     , io-streams
     , rncryptor -any
   hs-source-dirs:
@@ -81,7 +81,7 @@ executable rncryptor-encrypt
       base
     , bytestring
     , io-streams
-    , cryptonite
+    , cryptonite >= 0.15
     , rncryptor -any
   hs-source-dirs:
     example

--- a/src/Crypto/RNCryptor/Types.hs
+++ b/src/Crypto/RNCryptor/Types.hs
@@ -18,6 +18,7 @@ import Control.Applicative
 import Control.Monad
 import Crypto.Cipher.AES
 import Crypto.PBKDF.ByteString
+import Crypto.Hash.SHA256
 import Test.QuickCheck
 
 
@@ -84,7 +85,7 @@ newRNCryptorHeader userKey = do
       , rncEncryptionSalt = eSalt
       , rncHMACSalt = hmacSalt
       , rncIV = iv
-      , rncHMAC = const $ sha1PBKDF2 userKey hmacSalt 10000 32
+      , rncHMAC = hmac $ sha1PBKDF2 userKey hmacSalt 10000 32
       }
 
 --------------------------------------------------------------------------------

--- a/src/Crypto/RNCryptor/V3/Decrypt.hs
+++ b/src/Crypto/RNCryptor/V3/Decrypt.hs
@@ -39,7 +39,6 @@ parseHeader input = flip evalState input $ do
     , rncEncryptionSalt = eSalt
     , rncHMACSalt = hmacSalt
     , rncIV = iv
-    , rncHMAC = \bs pwd -> error "internal error, uninitialized HMAC alg"
     }
 
 --------------------------------------------------------------------------------
@@ -135,7 +134,7 @@ decrypt input pwd =
       hdr = parseHeader $ rawHdr
       ctx = newRNCryptorContext pwd hdr
       clearText = decrypt_ (ctxCipher ctx) (rncIV . ctxHeader $ ctx) cipherText
-      hmac = makeHMAC (rncHMACSalt . ctxHeader $ ctx)  pwd $ rawHdr <> cipherText
+      hmac = makeHMAC (rncHMACSalt . ctxHeader $ ctx) pwd $ rawHdr <> cipherText
   in
     if consistentTimeEqual msgHMAC hmac then removePaddingSymbols clearText else error "failed decrypt, invalid HMAC"
 

--- a/src/Crypto/RNCryptor/V3/Decrypt.hs
+++ b/src/Crypto/RNCryptor/V3/Decrypt.hs
@@ -82,10 +82,6 @@ parseIV :: State ByteString ByteString
 parseIV = parseBSOfSize 16 "parseIV: not enough bytes."
 
 --------------------------------------------------------------------------------
-parseHMAC :: ByteString -> ByteString
-parseHMAC leftover = flip evalState leftover $ parseBSOfSize 32 "parseHMAC: not enough bytes."
-
---------------------------------------------------------------------------------
 -- | This was taken directly from the Python implementation, see "post_decrypt_data",
 -- even though it doesn't seem to be a usual PKCS#7 removal:
 -- data = data[:-bord(data[-1])]
@@ -118,6 +114,8 @@ decryptBlock ctx cipherText =
       in (ctx { ctxHeader = newHeader, ctxHMACCtx = newHMACCtx }, clearText)
 
 --------------------------------------------------------------------------------
+-- TBD:  need strictness here to overcome lazy pull from zip results stopping at
+-- first False?
 consistentTimeEqual :: ByteString -> ByteString -> Bool
 consistentTimeEqual a b = and $ B.zipWith (==) a b
 

--- a/src/Crypto/RNCryptor/V3/Encrypt.hs
+++ b/src/Crypto/RNCryptor/V3/Encrypt.hs
@@ -5,7 +5,7 @@ module Crypto.RNCryptor.V3.Encrypt
   , encryptStream
   ) where
 
-import           Crypto.Cipher.AES          (AES128)
+import           Crypto.Cipher.AES          (AES256)
 import           Crypto.Cipher.Types        (makeIV, IV, BlockCipher, cbcEncrypt)
 import           Crypto.MAC.HMAC            (update, finalize)
 import           Crypto.RNCryptor.Padding
@@ -14,15 +14,15 @@ import           Crypto.RNCryptor.V3.Stream
 import           Data.ByteArray             (convert)
 import           Data.ByteString            (ByteString)
 import qualified Data.ByteString as B
-import           Data.Maybe                 (maybe)
+import           Data.Maybe                 (fromMaybe)
 import           Data.Monoid
 import qualified System.IO.Streams as S
 
-encrypt_ :: AES128 -> ByteString -> ByteString -> ByteString
+encrypt_ :: AES256 -> ByteString -> ByteString -> ByteString
 encrypt_ a iv clearText =
   cbcEncrypt a iv' clearText
   where
-    iv' = maybe (error "encrypt_ failed makeIV") id $ makeIV iv
+    iv' = fromMaybe (error "encrypt_ failed makeIV") $ makeIV iv
 
 --------------------------------------------------------------------------------
 -- | Encrypt a raw Bytestring block. The function returns the encrypt text block

--- a/src/Crypto/RNCryptor/V3/Encrypt.hs
+++ b/src/Crypto/RNCryptor/V3/Encrypt.hs
@@ -11,9 +11,9 @@ import           Crypto.RNCryptor.Types
 import           Crypto.RNCryptor.V3.Stream
 import           Crypto.RNCryptor.Padding
 import           Crypto.Cipher.AES
+import           Crypto.Hash.SHA256
 import           Data.Monoid
 import qualified System.IO.Streams as S
-
 
 --------------------------------------------------------------------------------
 -- | Encrypt a raw Bytestring block. The function returns the encrypt text block
@@ -38,8 +38,10 @@ encrypt :: RNCryptorContext -> ByteString -> ByteString
 encrypt ctx input =
   let hdr = ctxHeader ctx
       inSz = B.length input
-      (_, clearText) = encryptBlock ctx (input <> pkcs7Padding blockSize inSz)
-  in renderRNCryptorHeader hdr <> clearText <> (rncHMAC hdr $ mempty)
+      (_, cipherText) = encryptBlock ctx (input <> pkcs7Padding blockSize inSz)
+      msgHdr  = renderRNCryptorHeader hdr
+      msgHMAC = rncHMAC hdr $ msgHdr <> cipherText
+  in msgHdr <> cipherText <> msgHMAC
 
 --------------------------------------------------------------------------------
 -- | Efficiently encrypt an incoming stream of bytes.

--- a/src/Crypto/RNCryptor/V3/Encrypt.hs
+++ b/src/Crypto/RNCryptor/V3/Encrypt.hs
@@ -49,7 +49,7 @@ encrypt ctx input =
   let msgHdr  = renderRNCryptorHeader $ ctxHeader ctx
       ctx'    = ctx { ctxHMACCtx = update (ctxHMACCtx ctx) msgHdr }
       (ctx'', cipherText) = encryptBlock ctx' (input <> pkcs7Padding blockSize (B.length input))
-      msgHMAC = convert $ finalize (ctxHMACCtx ctx'')  -- msgHMAC = (rncHMAC hdr) key $ msgHdr <> cipherText
+      msgHMAC = convert $ finalize (ctxHMACCtx ctx'')
   in msgHdr <> cipherText <> msgHMAC
 
 --------------------------------------------------------------------------------

--- a/src/Crypto/RNCryptor/V3/Stream.hs
+++ b/src/Crypto/RNCryptor/V3/Stream.hs
@@ -9,7 +9,6 @@ import qualified Data.ByteString as B
 import           Data.Word
 import           Control.Monad.State
 import           Crypto.RNCryptor.Types
-import           Crypto.Cipher.AES
 import           Data.Monoid
 import qualified System.IO.Streams as S
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,3 +5,4 @@ packages:
 - '.'
 extra-deps:
   - pbkdf-1.1.1.1
+  - cryptohash-sha256-0.11.100.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,3 @@ install-ghc: true
 packages:
 - '.'
 extra-deps:
-  - pbkdf-1.1.1.1
-  - cryptohash-sha256-0.11.100.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-3.14
+resolver: lts-6.5
 system-ghc: false
 install-ghc: true
 packages:


### PR DESCRIPTION
More POC than anything else. 
Not implemented:  
  * incremental generation of HMAC for encryptStream API
  * validation of HMAC in equivalent decrypt and decryptStream APIs
Found incremental HMAC in cyptonite package.
Next steps 
  * verify compatibility with Crypto.Hash.SHA256 by using Crypto.MAC.HMAC.hmac instead.
  * use Crypto.MAC.HMAC initialize, update, and finalize for encryptStream API
  * verify HMAC in decrypt APIs 


  