### PR TITLE
bug fix:  use cipherText to update IV, not clearText

### DIFF
--- a/src/Crypto/RNCryptor/V3/Encrypt.hs
+++ b/src/Crypto/RNCryptor/V3/Encrypt.hs
@@ -35,7 +35,7 @@ encryptBlock ctx clearText =
   let cipherText = encryptBytes (ctxCipher ctx) (rncIV . ctxHeader $ ctx) clearText
       !newHmacCtx = update (ctxHMACCtx ctx) cipherText
       !sz         = B.length clearText
-      !newHeader  = (ctxHeader ctx) { rncIV = B.drop (sz - 16) clearText }
+      !newHeader  = (ctxHeader ctx) { rncIV = B.drop (sz - 16) cipherText }
       in (ctx { ctxHeader = newHeader, ctxHMACCtx = newHmacCtx }, cipherText)
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
trivial:  use cipherText to update IV, not clearText