### PR TITLE
Fixed #26 (Improve memory allocations; ditched io-streams)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ cabal.sandbox.config
 shell.nix
 cabal.config
 .stack-work
+test.sh
+*.prof

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ encrypted file format by Rob Napier.
 # Current Supported Versions
 * V3 - [Spec](https://github.com/RNCryptor/RNCryptor-Spec/blob/master/RNCryptor-Spec-v3.md)
 
+# Changelog
+
+* Version 0.4.0.0
+    + Removed `io-streams` dependency in favour of `streaming`
+
 # Requirements
 
 The library uses by default a fast C layer to compute the PBKDF2, but that requires the

--- a/example/StreamingDecrypter.hs
+++ b/example/StreamingDecrypter.hs
@@ -1,14 +1,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import Crypto.RNCryptor.V3.Decrypt
-import qualified System.IO.Streams as S
-import System.Environment
+import           Crypto.RNCryptor.V3.Decrypt
 import qualified Data.ByteString.Char8 as B
+import           System.Environment
+import           System.IO
+import qualified System.IO.Streams as S
 
 main :: IO ()
 main = do
   args <- getArgs
   case args of
-    key:_ -> decryptStream (B.pack key) S.stdin S.stdout
+    key:_ -> do
+      hSetBuffering stdin  NoBuffering
+      hSetBuffering stdout NoBuffering
+      decryptStream (B.pack key) S.stdin S.stdout
     _ -> putStrLn "usage: rncryptor-decrypt <key>"

--- a/example/StreamingDecrypter.hs
+++ b/example/StreamingDecrypter.hs
@@ -5,7 +5,6 @@ import           Crypto.RNCryptor.V3.Decrypt
 import qualified Data.ByteString.Char8 as B
 import           System.Environment
 import           System.IO
-import qualified System.IO.Streams as S
 
 main :: IO ()
 main = do
@@ -14,5 +13,5 @@ main = do
     key:_ -> do
       hSetBuffering stdin  NoBuffering
       hSetBuffering stdout NoBuffering
-      decryptStream (B.pack key) S.stdin S.stdout
+      decryptStream (B.pack key) stdin stdout
     _ -> putStrLn "usage: rncryptor-decrypt <key>"

--- a/example/StreamingEncrypter.hs
+++ b/example/StreamingEncrypter.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import Crypto.RNCryptor.V3.Encrypt
-import qualified System.IO.Streams as S
-import System.Environment
+import           Crypto.RNCryptor.V3.Encrypt
 import qualified Data.ByteString.Char8 as B
+import           System.Environment
+import           System.IO
 
 main :: IO ()
 main = do
   args <- getArgs
   case args of
-    key:_ -> encryptStream (B.pack key) S.stdin S.stdout
+    key:_ -> encryptStream (B.pack key) stdin stdout
     _ -> putStrLn "usage: rncryptor-encrypt <key>"

--- a/rncryptor.cabal
+++ b/rncryptor.cabal
@@ -1,5 +1,5 @@
 name:                rncryptor
-version:             0.3.0.0
+version:             0.4.0.0
 synopsis:            Haskell implementation of the RNCryptor file format
 description:         Pure Haskell implementation of the RNCrytor spec.
 license:             MIT
@@ -14,6 +14,10 @@ cabal-version:       >=1.10
 flag fastpbkdf2
      description: Use fastpbkdf2 instead of cryptonite for PBKDF2.
      default: True
+
+flag prof
+     description: Enable profiling options.
+     default: False
 
 source-repository head
   type:     git
@@ -31,6 +35,7 @@ library
   build-depends:
       base >=4.6 && < 5
     , bytestring >= 0.9.0
+    , bytestring-tree-builder
     , mtl >= 2.1
     , random >= 1.0.0.1
     , QuickCheck >= 2.6 && < 2.9
@@ -40,6 +45,8 @@ library
   if flag(fastpbkdf2)
     build-depends: fastpbkdf2
     cpp-options:  -DFASTPBKDF2
+  if flag(prof)
+   ghc-options: -fprof-auto -rtsopts -auto-all -caf-all
   hs-source-dirs:
     src
   default-language:
@@ -85,6 +92,8 @@ executable rncryptor-decrypt
     StreamingDecrypter.hs
   default-language:
     Haskell2010
+  if flag(prof)
+   ghc-options: -fprof-auto -rtsopts -auto-all -caf-all
   ghc-options:
     -funbox-strict-fields
 

--- a/rncryptor.cabal
+++ b/rncryptor.cabal
@@ -38,8 +38,8 @@ library
     , bytestring-tree-builder
     , mtl >= 2.1
     , random >= 1.0.0.1
+    , streaming < 0.2.0.0
     , QuickCheck >= 2.6 && < 2.9
-    , io-streams >= 1.2.0.0
     , cryptonite >= 0.15
     , memory
   if flag(fastpbkdf2)

--- a/src/Crypto/RNCryptor/V3/Stream.hs
+++ b/src/Crypto/RNCryptor/V3/Stream.hs
@@ -1,79 +1,71 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE UnboxedTuples #-}
 module Crypto.RNCryptor.V3.Stream
   ( processStream
-  , StreamingState(..)
   ) where
 
-import           ByteString.TreeBuilder as TB
 import           Control.Monad.State
 import           Crypto.RNCryptor.Types
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import           Data.Monoid
 import           Data.Word
-import qualified System.IO.Streams as S
-
---------------------------------------------------------------------------------
--- | The 'StreamingState' the streamer can be at. This is needed to drive the
--- computation as well as reading leftovers unread back in case we need to
--- chop the buffer read, if not multiple of the 'blockSize'.
-data StreamingState =
-    Continue
-  | FetchLeftOver !Int
-  | DrainSource deriving (Show, Eq)
+import qualified Streaming.Prelude as S
+import           System.IO as IO
 
 --------------------------------------------------------------------------------
 -- | Efficiently transform an incoming stream of bytes.
 processStream :: RNCryptorContext
               -- ^ The RNCryptor context for this operation
-              -> S.InputStream ByteString
-              -- ^ The input source (mostly likely stdin)
-              -> S.OutputStream ByteString
-              -- ^ The output source (mostly likely stdout)
+              -> Handle
+              -- ^ The input Handle (mostly likely stdin)
+              -> Handle
+              -- ^ The output Handle (mostly likely stdout)
               -> (RNCryptorContext -> ByteString -> (# RNCryptorContext, ByteString #))
               -- ^ The action to perform over the block
               -> (ByteString -> RNCryptorContext -> IO ())
               -- ^ The finaliser
               -> IO ()
-processStream context inS outS blockFn finaliser = do
-  processBlock Continue mempty context
+processStream context inHandle outHandle blockFn finaliser = do
+  let inS = fromHandle inHandle 64000
+  processBlock inS mempty context
   where
     slack input = let bsL = B.length input in (# bsL, bsL `mod` blockSize #)
 
-    processBlock :: StreamingState -> TB.Builder -> RNCryptorContext -> IO ()
-    processBlock dc iBuffer ctx = do
-      nextChunk <- readNextChunk inS dc
+    processBlock :: EncryptedStream -> B.ByteString -> RNCryptorContext -> IO ()
+    processBlock inS !leftover ctx = do
+      nextChunk <- S.uncons inS
       case nextChunk of
-        Nothing -> finaliser (TB.toByteString iBuffer) ctx
-        Just v -> do
-          let (# sz, sl #) = slack v
-          case dc of
-            DrainSource -> processBlock DrainSource (iBuffer <> TB.byteString v) ctx
-            _ -> do
-              whatsNext <- S.peek inS
-              case whatsNext of
-                Nothing -> finaliser (TB.toByteString (iBuffer <> TB.byteString v)) ctx
-                Just nt ->
-                  case sz + B.length nt < 4096 of
-                    True  -> processBlock DrainSource (iBuffer <> TB.byteString v) ctx
-                    False -> do
-                      -- If I'm here, it means I can safely process this chunk
-                      let (toProcess, rest) = B.splitAt (sz - sl) v
-                      let (# newCtx, res #) = blockFn ctx toProcess
-                      S.write (Just res) outS
-                      S.write (Just mempty) outS -- explicit flush.
-                      case sl == 0 of
-                        False -> do
-                          S.unRead rest inS
-                          processBlock (FetchLeftOver sl) iBuffer newCtx
-                        True -> processBlock Continue iBuffer newCtx
+        Nothing      -> finaliser leftover ctx
+        Just ("", _) -> finaliser leftover ctx
+        Just (currentBlock, nextStream) -> do
+          whatsNext <- S.uncons nextStream
+          case whatsNext of
+            Nothing      -> finaliser (leftover <> currentBlock) ctx
+            Just ("", _) -> finaliser (leftover <> currentBlock) ctx
+            Just (lookAheadChunk, lookAheadStream)  -> do
+              let toDecrypt = leftover <> currentBlock <> lookAheadChunk
+              let (# sz, sl #) = slack toDecrypt
+              let (toProcess, rest) = B.splitAt (sz - sl) toDecrypt
+              let (# newCtx, res #) = blockFn ctx toProcess
+              B.hPut outHandle res
+              hFlush outHandle
+              case sl == 0 of
+                True  -> processBlock nextStream mempty newCtx
+                False -> processBlock nextStream rest newCtx
+
+
+type EncryptedStream = S.Stream (S.Of B.ByteString) IO ()
 
 --------------------------------------------------------------------------------
-readNextChunk :: S.InputStream ByteString -> StreamingState -> IO (Maybe ByteString)
-readNextChunk inS streamingState = case streamingState of
-    FetchLeftOver size -> do
-      lo <- S.readExactly size inS
-      p  <- S.read inS
-      return $! fmap (mappend lo) p
-    _ -> S.read inS
+fromHandle :: IO.Handle -> Int -> EncryptedStream
+fromHandle h bufSize = go
+  where
+    go = do
+        eof <- liftIO $ IO.hIsEOF h
+        unless eof $ do
+            str <- liftIO $ B.hGet h bufSize
+            S.yield str
+            go
+{-# INLINABLE fromHandle #-}


### PR DESCRIPTION
This PR mainly fixes #26.

It also comes with the following breaking changes:

* I've ditched `io-streams` in favour of `streaming`. The former, despite being a lovely library, wasn't the right fit for the job, because it uses a pre-allocated buffer which is not multiple of the `blockSize`, and this was creating lots of `read` and `unRead`, ultimately leading to huge memory spikes of 400+ MB on my machine, to decrypt a 1.22 GB file. The current implementation is constant at 2.4 MB of virtual memory.