### PR TITLE
Fixed #28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ cabal.sandbox.config
 shell.nix
 cabal.config
 .stack-work
+dist
+dist-newstyle
+cabal.project.local
+.cabal.project.local
+tags

--- a/rncryptor.cabal
+++ b/rncryptor.cabal
@@ -33,7 +33,7 @@ library
     , bytestring >= 0.9.0
     , mtl >= 2.1
     , random >= 1.0.0.1
-    , QuickCheck >= 2.6 && < 2.9
+    , QuickCheck >= 2.6 && < 3.0
     , io-streams >= 1.2.0.0
     , cryptonite >= 0.15
     , memory

--- a/stack-12.19.yaml
+++ b/stack-12.19.yaml
@@ -1,0 +1,8 @@
+resolver: lts-12.19
+install-ghc: true
+flags: {}
+packages:
+- '.'
+system-ghc: false
+extra-deps:
+    - fastpbkdf2-0.1.0.0


### PR DESCRIPTION
This commit allows this library to be compiled against GHC 8.4.4 and the
most recent LTS.

@Mikolaj this should do the trick! Tested with both stack TLS-12.19 and cabal new-build.