### PR TITLE
v0.3.0.3: fix for ghc-9.6/base-4.18.1.0

### DIFF
--- a/rncryptor.cabal
+++ b/rncryptor.cabal
@@ -1,5 +1,5 @@
 name:                rncryptor
-version:             0.3.0.2
+version:             0.3.0.3
 synopsis:            Haskell implementation of the RNCryptor file format
 description:         Pure Haskell implementation of the RNCrytor spec.
 license:             MIT

--- a/src/Crypto/RNCryptor/V3/Decrypt.hs
+++ b/src/Crypto/RNCryptor/V3/Decrypt.hs
@@ -7,6 +7,7 @@ module Crypto.RNCryptor.V3.Decrypt
   , decryptStream
   ) where
 
+import           Control.Monad               (unless)
 import           Control.Monad.State
 import           Control.Exception           (throwIO)
 import           Crypto.Cipher.AES           (AES256)

--- a/stack-9.4.yaml
+++ b/stack-9.4.yaml
@@ -1,5 +1,4 @@
-# resolver: lts-21.20
-resolver: nightly-2023-11-15
+resolver: lts-21.20
 
 packages:
 - '.'


### PR DESCRIPTION
Source `unless` from `Control.Monad